### PR TITLE
use even more single-letter variables in list comprehensions to avoid overwriting variables outside of list comprehensions when using Python 2

### DIFF
--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -334,7 +334,7 @@ def det_easyconfig_paths(orig_paths):
     :return: list of paths to easyconfig files
     """
     try:
-        from_prs = [int(pr_nr) for pr_nr in build_option('from_pr')]
+        from_prs = [int(x) for x in build_option('from_pr')]
     except ValueError:
         raise EasyBuildError("Argument to --from-pr must be a comma separated list of PR #s.")
 

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -1464,7 +1464,7 @@ def set_up_configuration(args=None, logfile=None, testing=False, silent=False):
 
     # map list of strings --from-pr value to list of integers
     try:
-        from_prs = [int(pr_nr) for pr_nr in eb_go.options.from_pr]
+        from_prs = [int(x) for x in eb_go.options.from_pr]
     except ValueError:
         raise EasyBuildError("Argument to --from-pr must be a comma separated list of PR #s.")
 
@@ -1500,7 +1500,7 @@ def set_up_configuration(args=None, logfile=None, testing=False, silent=False):
     # done here instead of in _postprocess_include because github integration requires build_options to be initialized
     if eb_go.options.include_easyblocks_from_pr:
         try:
-            easyblock_prs = [int(pr_nr) for pr_nr in eb_go.options.include_easyblocks_from_pr]
+            easyblock_prs = [int(x) for x in eb_go.options.include_easyblocks_from_pr]
         except ValueError:
             raise EasyBuildError("Argument to --include-easyblocks-from-pr must be a comma separated list of PR #s.")
 

--- a/easybuild/tools/testing.py
+++ b/easybuild/tools/testing.py
@@ -151,7 +151,7 @@ def create_test_report(msg, ecs_with_res, init_session_state, pr_nrs=None, gist_
     test_report = []
     if pr_nrs is not None:
         repo = pr_target_repo or GITHUB_EASYCONFIGS_REPO
-        pr_urls = ["https://github.com/%s/%s/pull/%s" % (pr_target_account, repo, pr_nr) for pr_nr in pr_nrs]
+        pr_urls = ["https://github.com/%s/%s/pull/%s" % (pr_target_account, repo, x) for x in pr_nrs]
         test_report.extend([
             "Test report for %s" % ', '.join(pr_urls),
             "",
@@ -193,7 +193,7 @@ def create_test_report(msg, ecs_with_res, init_session_state, pr_nrs=None, gist_
                 descr = "(partial) EasyBuild log for failed build of %s" % ec['spec']
 
                 if pr_nrs is not None:
-                    descr += " (PR #%s)" % ', #'.join(str(pr_nr) for pr_nr in pr_nrs)
+                    descr += " (PR #%s)" % ', #'.join(str(x) for x in pr_nrs)
 
                 if easyblock_pr_nrs:
                     descr += "".join(" (easyblock PR #%s)" % nr for nr in easyblock_pr_nrs)
@@ -295,7 +295,7 @@ def post_pr_test_report(pr_nr, repo_type, test_report, msg, init_session_state, 
 
     if build_option('include_easyblocks_from_pr'):
         if repo_type == GITHUB_EASYCONFIGS_REPO:
-            easyblocks_pr_nrs = [int(eb_pr_nr) for eb_pr_nr in build_option('include_easyblocks_from_pr')]
+            easyblocks_pr_nrs = [int(x) for x in build_option('include_easyblocks_from_pr')]
             comment_lines.append("Using easyblocks from PR(s) %s" %
                                  ", ".join(["https://github.com/%s/%s/pull/%s" %
                                             (pr_target_account, GITHUB_EASYBLOCKS_REPO, easyblocks_pr_nr)
@@ -333,12 +333,12 @@ def overall_test_report(ecs_with_res, orig_cnt, success, msg, init_session_state
     dump_path = build_option('dump_test_report')
 
     try:
-        pr_nrs = [int(pr_nr) for pr_nr in build_option('from_pr')]
+        pr_nrs = [int(x) for x in build_option('from_pr')]
     except ValueError:
         raise EasyBuildError("Argument to --from-pr must be a comma separated list of PR #s.")
 
     try:
-        easyblock_pr_nrs = [int(pr_nr) for pr_nr in build_option('include_easyblocks_from_pr')]
+        easyblock_pr_nrs = [int(x) for x in build_option('include_easyblocks_from_pr')]
     except ValueError:
         raise EasyBuildError("Argument to --include-easyblocks-from-pr must be a comma separated list of PR #s.")
 


### PR DESCRIPTION
… to avoid overwriting variables outside of list comprehensions when using Python 2