### PR TITLE
Revert change to expected test output from #4818

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -2329,6 +2329,9 @@ def process_easyconfig(path, build_specs=None, validate=True, parse_only=False, 
     if not build_specs:
         cache_key = (path, validate, hidden, parse_only)
         if cache_key in _easyconfigs_cache:
+            # Note: This does NOT copy EasyConfig instances but the dict containing an instance in the 'ec' key.
+            # So modifications to the `EasyConfig` instance will be shared.
+            # TODO: Implement proper (deep)-copy
             return [e.copy() for e in _easyconfigs_cache[cache_key]]
 
     easyconfigs = []
@@ -2354,6 +2357,9 @@ def process_easyconfig(path, build_specs=None, validate=True, parse_only=False, 
         easyconfigs.append(easyconfig)
 
     if cache_key is not None:
+        # Note: This does NOT copy EasyConfig instances but the dict containing an instance in the 'ec' key.
+        # So modifications to the `EasyConfig` instance will be shared.
+        # TODO: Implement proper (deep)-copy
         _easyconfigs_cache[cache_key] = [e.copy() for e in easyconfigs]
 
     return easyconfigs

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -3678,9 +3678,6 @@ class ToyBuildTest(EnhancedTestCase):
             Parse Hook toy 0.0
             ['%(name)s-%(version)s.tar.gz']
             echo toy
-            Parse Hook toy 0.0
-            ['%(name)s-%(version)s.tar.gz']
-            echo toy
             installing 1 easyconfigs: toy/0.0
             starting installation of toy 0.0
             pre-configure: toy.source: True


### PR DESCRIPTION
#4818 accounted for the extra parse of the main easyconfig (but seemingly not for dependencies)